### PR TITLE
JaCoCo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,45 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.3</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<rules>
+						<rule>
+							<element>BUNDLE</element>
+							<limits>
+								<limit>
+									<counter>INSTRUCTION</counter>
+									<value>COVEREDRATIO</value>
+									<minimum>0.00</minimum>
+								</limit>
+								<limit>
+									<counter>BRANCH</counter>
+									<value>COVEREDRATIO</value>
+									<minimum>0.00</minimum>
+								</limit>
+							</limits>
+						</rule>
+					</rules>
+				</configuration>
+			</plugin>
+
+			<plugin>
 				<groupId>org.datanucleus</groupId>
 				<artifactId>datanucleus-maven-plugin</artifactId>
 				<version>5.0.2</version>
@@ -92,7 +131,7 @@
 
 		</plugins>
 	</build>
-
+	
 	<profiles>
 		<!-- run as 'mvn exec:java -Pserver' -->
 		<profile>


### PR DESCRIPTION
Updated just the pom.xml file. Now, running `mvn test`, in addition to check the tests, the JaCoCo report is generated in the path `/target/site/jacoco`.