### PR TITLE
Report generation

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -10,11 +10,11 @@ mvn exec:java -Pclient
 Launch MySQL:
 mysqld --console --explicit_defaults_for_timestamp --default-time-zone=+00:00
 
-For creating the DB Schema:
-mvn datanucleus:schema-create
-
-For deleting DB Schema:
-mvn datanucleus:schema-delete
-
 For running Test:
 mvn test
+
+Report generation:
+mvn test
+mvn checkstyle:checkstyle
+mvn jdepend:generate
+mvn site

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.7.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
@@ -132,6 +132,55 @@
 		</plugins>
 	</build>
 	
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.0.1</version>
+				<configuration>
+					<show>private</show>
+					<nohelp>true</nohelp>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-project-info-reports-plugin</artifactId>
+				<version>2.9</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.0.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>jdepend-maven-plugin</artifactId>
+				<version>2.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-report-plugin</artifactId>
+				<version>2.21.0</version>
+			</plugin>
+			<plugin>
+				<groupId>com.googlecode.maven-overview-plugin</groupId>
+				<artifactId>maven-overview-plugin</artifactId>
+				<version>1.6</version>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.3</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>3.11.0</version>
+			</plugin>
+		</plugins>
+	</reporting>
+
 	<profiles>
 		<!-- run as 'mvn exec:java -Pserver' -->
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.7.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>9</source>
+					<target>9</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Updated the pom.xml file, so that now it's possible to generate HTML reports. It is done executing the following commands:
1. `mvn test`
2. `mvn checkstyle:checkstyle`
3. `mvn jdepend:generate`
4. `mvn site`

The report is generated in the `/target/site` directory, and can be opened through `index.html` (select "Project Reports" in the menu located in the top-left-most corner). 

Note that lines 69 and 70 in the pom.xml file indicate the JDK version. It must be indicated the JDK version of your computer, between 9 and 11 (inclusive). It is not possible to run under the version 9 due to the dependencies of the project, nor version 12 (or above) yet they are not compatible.