### PR TITLE
Jacoco package exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,10 @@
 					</execution>
 				</executions>
 				<configuration>
+				    <excludes>
+                        <exclude>**/client/gui/**</exclude>
+                        <exclude>**/server/data/jdo/**</exclude>
+					</excludes>
 					<rules>
 						<rule>
 							<element>BUNDLE</element>


### PR DESCRIPTION
The `pom.xml` file has been updated to exclude some packages from the report generated by the jacoco plugin. These are the excluded packages so far:
- `client/gui`
- `server/data/jdo`

A consecuence of those exclusions is the test coverage percentage.