### PR TITLE
Upgrade Travis to OpenJDK10 to fix build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 language: java
 jdk:
-  - openjdk9
+  - openjdk10
 services:
   - xvfb
   - mysql


### PR DESCRIPTION
This will fix builds across all branches.

Travis randomly started failing for OpenJDK9.